### PR TITLE
Add Parsedown Extended and Math support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this line to your LocalSettings.php:
 wfLoadExtension( 'WikiMarkdown' );
 ```
 
-This extension requires [Parsedown](https://github.com/erusev/parsedown) to be installed and optionally [Parsedown Extra](https://github.com/erusev/parsedown-extra).  Either install them manually, or use Composer by adding the line `"extensions/WikiMarkdown/composer.json"` to the "composer.local.json" file in the root directory of your wiki, e.g.
+This extension requires [Parsedown](https://github.com/erusev/parsedown) to be installed and optionally [Parsedown Extra](https://github.com/erusev/parsedown-extra) and [Parsedown Extended](https://github.com/BenjaminHoegh/ParsedownExtended).  Either install them manually, or use Composer by adding the line `"extensions/WikiMarkdown/composer.json"` to the "composer.local.json" file in the root directory of your wiki, e.g.
 ```json
 {
 	"extra": {
@@ -54,11 +54,14 @@ _This is italic text_
 
 # Configuration
 
-* `$wgAllowMarkdownExtra` (optional): Set to `true` in order to specify that Parsedown Extra should be used.
+* `$wgAllowMarkdownExtra` (optional): Set to `true` in order to specify that [Parsedown Extra](https://github.com/erusev/parsedown-extra) should be used.
+* `$wgAllowMarkdownExtended` (optional): Set to `true` in order to specify that [Parsedown Extended](https://github.com/BenjaminHoegh/ParsedownExtended) should be used.
+* `$wgParsedownExtendedParameters` (optional): Allows for specifying the options that are passed to Parsedown Extended.  See the [documentation](https://benjaminhoegh.github.io/ParsedownExtended/) for which options you want to enable or disable.
 
 # Other Features
 * This extension also functions as a content handler for wiki pages ending in `.md`.  For these pages, the entire page will be interpreted as markdown and markdown syntax highlighting will be used in the editor if you have the [CodeEditor](https://www.mediawiki.org/wiki/Extension:CodeEditor) extension installed.
 * When specifying code blocks in markdown, this extension will automatically apply the [SyntaxHighlight](https://www.mediawiki.org/wiki/Extension:SyntaxHighlight) extension if it is installed.  All languages supported by the SyntaxHighlight extension will work.
+* When using Parsedown Extended, this extension will automatically apply the [Math](https://www.mediawiki.org/wiki/Extension:Math) extension if it is installed to any math blocks by default.  This can be turned off by either not using Parsedown Extended, or modifying `$wgParsedownExtendedParameters`.  The following syntaxes are valid: `\[ ... \]`/`$$ ... $$` (for block mode) and `\( ... \)`/`$ ... $` (for inline mode)
 * When using the [VisualEditor](https://www.mediawiki.org/wiki/Extension:VisualEditor) extension with the CodeEditor extension, markdown blocks will be editable using a markdown editor.
 
 # Credits

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,9 @@
 	"name": "mediawiki/wikimarkdown",
 	"description": "Markdown syntax for MediaWiki",
 	"require": {
-		"erusev/parsedown": "^1.7.4",
-		"erusev/parsedown-extra": "^0.8.1"
+		"erusev/parsedown": "^1.8.0-beta-7",
+		"erusev/parsedown-extra": "^0.8.1",
+		"benjaminhoegh/parsedown-extended": "^1.1.1"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "31.0.0",
@@ -18,7 +19,8 @@
 		}
 	],
 	"suggest": {
-		"erusev/parsedown-extra": "Optional extra package"
+		"erusev/parsedown-extra": "Optional extra package",
+		"benjaminhoegh/parsedown-extended": "Optional extra package"
 	},
 	"scripts": {
 		"fix": [

--- a/extension.json
+++ b/extension.json
@@ -43,6 +43,18 @@
 	"config": {
 		"AllowMarkdownExtra": {
 			"value": false
+		},
+		"AllowMarkdownExtended": {
+			"value": false
+		},
+		"ParsedownExtendedParameters": {
+			"value": {
+				"math": {
+					"single_dollar": true
+				},
+				"sup": true,
+				"sub": true
+			}
 		}
 	},
 	"ContentHandlers": {


### PR DESCRIPTION
This resolves #3.  In order to support mathematical equations inside markdown, [Parsedown Extended](https://github.com/BenjaminHoegh/ParsedownExtended) must be installed and `$wgAllowMarkdownExtended` must be set to `true`.  When the [Math](https://www.mediawiki.org/wiki/Extension:Math) extension is installed, WikiMarkdown will use that to render.  Otherwise, you could potentially use a JavaScript solution such as [KaTeX](https://katex.org/), but that is untested and not officially supported by this extension.

# Note:
There is currently an issue with Parsedown Extended preventing auto-loading from working with Composer.  This is fixed by BenjaminHoegh/ParsedownExtended#40, but the fix hasn't been released to Packagist yet.  For the time being, you can apply the fix manually or install Parssdown Extended manually to get it to work.