### PR TITLE
Update WikiMarkdown to fit parsedown-extended 1.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ _This is italic text_
 
 # Configuration
 
-* `$wgAllowMarkdownExtra` (optional): Set to `true` in order to specify that [Parsedown Extra](https://github.com/erusev/parsedown-extra) should be used.
-* `$wgAllowMarkdownExtended` (optional): Set to `true` in order to specify that [Parsedown Extended](https://github.com/BenjaminHoegh/ParsedownExtended) should be used.
-* `$wgParsedownExtendedParameters` (optional): Allows for specifying the options that are passed to Parsedown Extended.  See the [documentation](https://benjaminhoegh.github.io/ParsedownExtended/) for which options you want to enable or disable.
+* `$wgAllowMarkdownExtra` (optional): Set to `true` in order to specify that [Parsedown Extra](https://github.com/erusev/parsedown-extra) should be used. (default: `true`)
+* `$wgAllowMarkdownExtended` (optional): Set to `true` in order to specify that [Parsedown Extended](https://github.com/BenjaminHoegh/ParsedownExtended) should be used. (default: `true`)
+* ~~`$wgParsedownExtendedParameters` (optional): Allows for specifying the options that are passed to Parsedown Extended.  See the [documentation](https://benjaminhoegh.github.io/ParsedownExtended/) for which options you want to enable or disable.~~ For compatibility to Parsedown and ParseExtra, this branch remove this option and default to [that of ParsedownExtended](https://github.com/BenjaminHoegh/ParsedownExtended/blob/main/src/ParsedownExtended.php#L36).
 
 # Other Features
 * This extension also functions as a content handler for wiki pages ending in `.md`.  For these pages, the entire page will be interpreted as markdown and markdown syntax highlighting will be used in the editor if you have the [CodeEditor](https://www.mediawiki.org/wiki/Extension:CodeEditor) extension installed.

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,9 @@
 	"name": "mediawiki/wikimarkdown",
 	"description": "Markdown syntax for MediaWiki",
 	"require": {
-		"erusev/parsedown": "^1.8.0-beta-7",
+		"erusev/parsedown": "^1.7.4",
 		"erusev/parsedown-extra": "^0.8.1",
-		"benjaminhoegh/parsedown-extended": "^1.1.2"
+		"benjaminhoegh/parsedown-extended": "1.2.9"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "31.0.0",

--- a/extension.json
+++ b/extension.json
@@ -42,19 +42,10 @@
 	"callback": "WikiMarkdown::onRegistration",
 	"config": {
 		"AllowMarkdownExtra": {
-			"value": false
+			"value": true
 		},
 		"AllowMarkdownExtended": {
-			"value": false
-		},
-		"ParsedownExtendedParameters": {
-			"value": {
-				"math": {
-					"single_dollar": true
-				},
-				"sup": true,
-				"sub": true
-			}
+			"value": true
 		}
 	},
 	"ContentHandlers": {


### PR DESCRIPTION
The Latex and code rendering works fine in the official docker image (Mediawiki 1.41).