### PR TITLE
ResourceLoaderFileModule – use MediaWiki\ResourceLoader\FileModule

### DIFF
--- a/includes/ResourceLoaderWikiMarkdownVisualEditorModule.php
+++ b/includes/ResourceLoaderWikiMarkdownVisualEditorModule.php
@@ -1,6 +1,6 @@
 <?php
 
-class ResourceLoaderWikiMarkdownVisualEditorModule extends ResourceLoaderFileModule {
+class ResourceLoaderWikiMarkdownVisualEditorModule extends MediaWiki\ResourceLoader\FileModule {
 
 	protected $targets = [ 'desktop', 'mobile' ];
 

--- a/includes/ResourceLoaderWikiMarkdownVisualEditorModule.php
+++ b/includes/ResourceLoaderWikiMarkdownVisualEditorModule.php
@@ -8,7 +8,7 @@ class ResourceLoaderWikiMarkdownVisualEditorModule extends MediaWiki\ResourceLoa
 	 * @param ResourceLoaderContext $context
 	 * @return string JavaScript code
 	 */
-	public function getScript( ResourceLoaderContext $context ) {
+	public function getScript( MediaWiki\ResourceLoader\Context $context ) {
 		$scripts = parent::getScript( $context );
 
 		return $scripts;


### PR DESCRIPTION
Fixes visual editor on Mediawiki 1.42+.

https://www.mediawiki.org/wiki/Release_notes/1.42